### PR TITLE
Reset timer on screen unlock (Win + L)

### DIFF
--- a/PauseMe/MainForm.Designer.cs
+++ b/PauseMe/MainForm.Designer.cs
@@ -141,6 +141,7 @@
             this.cmsMain.PerformLayout();
             this.ResumeLayout(false);
 
+            Microsoft.Win32.SystemEvents.SessionSwitch += new Microsoft.Win32.SessionSwitchEventHandler(SessionSwitchHandler);
         }
 
         #endregion

--- a/PauseMe/MainForm.cs
+++ b/PauseMe/MainForm.cs
@@ -63,11 +63,7 @@ namespace PauseMe
 
         private void startToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            tmrMain.Start();
-            _TimerStarted = DateTime.Now;
-            tmrUpdateStatus.Start();
-
-            tbxStatus.Text = "Running";
+            frm_Restart();
         }
 
         private void pauseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -109,14 +105,21 @@ namespace PauseMe
 
         void frm_FormClosed(object sender, FormClosedEventArgs e)
         {
+            frm_Restart();
+        }
+
+        private void frm_Restart()
+        {
             foreach (var frm in _OpenForms.ToArray())
             {
                 frm.FormClosed -= frm_FormClosed;
                 frm.Close();
             }
 
+            tmrMain.Stop();
             tmrMain.Start();
             _TimerStarted = DateTime.Now;
+            tmrUpdateStatus.Stop();
             tmrUpdateStatus.Start();
         }
 
@@ -133,6 +136,22 @@ namespace PauseMe
 
             tbxStatus.Text = "Running (" + minutesPassed + ":" + secondsPassed + ")";
             niMain.Text = "Pause Me - Running (" + minutesPassed + ":" + secondsPassed + ")";
+        }
+
+        void SessionSwitchHandler(object sender, Microsoft.Win32.SessionSwitchEventArgs e)
+        {
+            if (e.Reason == Microsoft.Win32.SessionSwitchReason.SessionLock)
+            {
+                tmrMain.Stop();
+                tmrUpdateStatus.Stop();
+            }
+            else if (e.Reason == Microsoft.Win32.SessionSwitchReason.SessionUnlock)
+            {
+                if (tbxStatus.Text != "Stopped")
+                {
+                    frm_Restart();
+                }
+            }
         }
     }
 }

--- a/PauseMe/MainForm.cs
+++ b/PauseMe/MainForm.cs
@@ -116,7 +116,7 @@ namespace PauseMe
                 frm.Close();
             }
 
-            tmrMain.Stop();
+            tmrMain.Stop();     // Stop() is a hack to reset timer in case it's not stopped
             tmrMain.Start();
             _TimerStarted = DateTime.Now;
             tmrUpdateStatus.Stop();
@@ -151,6 +151,7 @@ namespace PauseMe
                 {
                     frm_Restart();
                 }
+                // else preserve paused state
             }
         }
     }

--- a/PauseMe/Program.cs
+++ b/PauseMe/Program.cs
@@ -12,7 +12,7 @@ namespace PauseMe
         [STAThread]
         static void Main()
         {
-            var settings = new Settings(new TimeSpan(0, 20, 0), new TimeSpan(0, 0, 20));
+            var settings = new Settings(new TimeSpan(0, 0, 20), new TimeSpan(0, 0, 20));
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/PauseMe/Program.cs
+++ b/PauseMe/Program.cs
@@ -12,7 +12,7 @@ namespace PauseMe
         [STAThread]
         static void Main()
         {
-            var settings = new Settings(new TimeSpan(0, 0, 20), new TimeSpan(0, 0, 20));
+            var settings = new Settings(new TimeSpan(0, 20, 0), new TimeSpan(0, 0, 20));
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);


### PR DESCRIPTION
## Changes
1. Timer is stopped when user locks his screen
2. Timer is restarted to count down the whole interval when user unlocks his screen
3. Bug fix: If user hit Start button in Running status, the visible counter was reset to the beginning but the timer didn't reflect the change. This resulted in opening the overlay before it's time. 